### PR TITLE
Fix hero link anchor

### DIFF
--- a/src/components/HeroSection.jsx
+++ b/src/components/HeroSection.jsx
@@ -52,7 +52,7 @@ export default function HeroSection() {
         </motion.p>
 
         <motion.a
-          href="#membresias"
+          href="#membership"
           className="hero-button"
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Summary
- fix hero button link so it anchors to membership section

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6875995c9150832e842cc1457c07ab45