### PR TITLE
feat: apply FitPlan palette and add routine CTA

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   <title>Asesoramiento físico MZ </title>
   <link rel="icon" href="/favicon.ico">
 </head>
-<body>
+<body class="landing">
   <div id="root"></div>
   <script type="module" src="/src/main.jsx"></script>
 </body>

--- a/src/components/FinalSection.css
+++ b/src/components/FinalSection.css
@@ -1,6 +1,6 @@
 .final {
   position: relative;
-  background-color: #000;
+  background-color: var(--color-background);
   padding: 60px 20px;
   text-align: center;
   overflow: hidden;
@@ -27,7 +27,7 @@
 
 .final-title {
   font-family: 'Anton', sans-serif;
-  color: #D7FB00;
+  color: var(--color-primary);
   font-size: 3rem;
   margin-bottom: 30px;
   animation: titleGlow 4s ease-in-out infinite;
@@ -35,16 +35,16 @@
 
 @keyframes titleGlow {
   0%, 100% {
-    text-shadow: 0 0 10px #D7FB00;
+    text-shadow: 0 0 10px var(--color-primary);
   }
   50% {
-    text-shadow: 0 0 20px #D7FB00;
+    text-shadow: 0 0 20px var(--color-primary);
   }
 }
 
 .final-text {
   font-family: 'Inter', sans-serif;
-  color: #ccc;
+  color: var(--color-text-neutral);
 
   font-size: 1.4rem;
   margin-bottom: 24px;
@@ -65,30 +65,10 @@
   height: auto;
 }
 
-.final-button {
-  background-color: #D7FB00;
-  color: #000;
-  font-family: 'Inter', sans-serif;
-  font-weight: 700;
-  padding: 12px 28px;
-  border-radius: 50px;
-  text-decoration: none;
-  transition: background-color 0.3s, color 0.3s;
-  animation: pulseButton 3s ease-in-out infinite;
-}
-
-@keyframes pulseButton {
-  0%, 100% {
-    box-shadow: 0 0 0 0 rgba(215, 251, 0, 0.7);
-  }
-  50% {
-    box-shadow: 0 0 20px 5px rgba(215, 251, 0, 0.7);
-  }
-}
-
-.final-button:hover {
-  background-color: #fff;
-  color: #000;
+.final-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
 }
 
 /* Desktop layout */
@@ -109,5 +89,9 @@
 
   .final-icon {
     width: 70px;
+  }
+
+  .final-buttons {
+    flex-direction: row;
   }
 }

--- a/src/components/FinalSection.jsx
+++ b/src/components/FinalSection.jsx
@@ -6,8 +6,8 @@ export default function FinalSection() {
       <svg className="final-texture" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
         <defs>
           <pattern id="finalGrid" patternUnits="userSpaceOnUse" width="30" height="30">
-            <path d="M0 0 L0 30 M0 0 L30 0" stroke="#D7FB00" strokeWidth="0.8" />
-            <path d="M0 30 L30 0 M0 0 L30 30" stroke="#D7FB00" strokeWidth="0.8" />
+            <path d="M0 0 L0 30 M0 0 L30 0" stroke="#CBFF00" strokeWidth="0.8" />
+            <path d="M0 30 L30 0 M0 0 L30 30" stroke="#CBFF00" strokeWidth="0.8" />
 
           </pattern>
         </defs>
@@ -26,9 +26,19 @@ export default function FinalSection() {
 
         <div className="final-icons">
           <img src="/dumbell.png" alt="Dumbell icon" className="final-icon" />
-          <a href="https://wa.me/5493512800414" target="_blank" rel="noopener noreferrer" className="final-button">
-            Quiero mi plan
-          </a>
+          <div className="final-buttons">
+            <a href="/rutinas" className="cta-button primary">
+              Quiero mi rutina ideal!
+            </a>
+            <a
+              href="https://wa.me/5493512800414"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="cta-button secondary"
+            >
+              Hablame y empecemos a entrenar!
+            </a>
+          </div>
           <img src="/plate.png" alt="Weight plate icon" className="final-icon" />
         </div>
       </div>

--- a/src/components/HeroSection.css
+++ b/src/components/HeroSection.css
@@ -6,7 +6,7 @@
   align-items: center;
   justify-content: center;
   padding: 50px 20px;
-  background-color: #000;
+  background-color: var(--color-background);
   position: relative;
   overflow: hidden;
 }
@@ -24,33 +24,33 @@
   color: white;
   margin-bottom: 20px;
   line-height: 1.2;
-  text-shadow: 2px 2px 0 #D7FB00;
+  text-shadow: 2px 2px 0 var(--color-primary);
   letter-spacing: 1px;
   animation: heroPulse 3s ease-in-out infinite;
 }
 
 @keyframes heroPulse {
   0% {
-    text-shadow: 0 0 10px #D7FB00;
+    text-shadow: 0 0 10px var(--color-primary);
   }
   50% {
-    text-shadow: 0 0 20px #D7FB00;
+    text-shadow: 0 0 20px var(--color-primary);
   }
   100% {
-    text-shadow: 0 0 10px #D7FB00;
+    text-shadow: 0 0 10px var(--color-primary);
   }
 }
 
 .hero-title .highlight {
-  background: linear-gradient(90deg, #D7FB00 0%, #D7FB00 100%);
-  color: #000;
+  background: linear-gradient(90deg, var(--color-primary) 0%, var(--color-primary) 100%);
+  color: var(--color-background);
   padding: 0 8px;
   border-radius: 4px;
 }
 
 .hero-description {
   font-family: 'Inter', sans-serif;
-  color: #ccc;
+  color: var(--color-text-neutral);
   margin-bottom: 14px;
   line-height: 1.8;
 
@@ -59,18 +59,24 @@
 }
 
 .hero-description strong {
-  color: #D7FB00;
+  color: var(--color-primary);
 }
 
 .hero-button {
-  background-color: #D7FB00;
-  color: #000;
+  background-color: var(--color-primary);
+  color: var(--color-background);
   padding: 12px 28px;
   border-radius: 6px;
   text-decoration: none;
   font-weight: bold;
   display: inline-block;
   margin-top: 20px;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.hero-button:hover {
+  background-color: var(--color-primary-hover);
+  color: var(--color-background);
 }
 
 .hero-image {

--- a/src/components/MembershipSection.css
+++ b/src/components/MembershipSection.css
@@ -1,6 +1,6 @@
 .membership {
   position: relative;
-  background-color: #000;
+  background-color: var(--color-background);
   padding: 50px 20px;
   overflow: hidden;
 }
@@ -16,21 +16,21 @@
 
 .membership-title {
   font-family: 'Anton', sans-serif;
-  color: #D7FB00;
+  color: var(--color-primary);
 
   font-size: 3rem;
   margin-bottom: 50px;
-  text-shadow: 2px 2px 0 #000;
+  text-shadow: 2px 2px 0 var(--color-background);
   letter-spacing: 1px;
   animation: titleGlow 4s ease-in-out infinite;
 }
 
 @keyframes titleGlow {
   0%, 100% {
-    text-shadow: 2px 2px 0 #000, 0 0 10px #D7FB00;
+    text-shadow: 2px 2px 0 var(--color-background), 0 0 10px var(--color-primary);
   }
   50% {
-    text-shadow: 2px 2px 0 #000, 0 0 20px #D7FB00;
+    text-shadow: 2px 2px 0 var(--color-background), 0 0 20px var(--color-primary);
   }
 
 }
@@ -44,13 +44,13 @@
 
 .plan-card {
   position: relative;
-  background: radial-gradient(circle at top left, rgba(215, 251, 0, 0.15), rgba(0, 0, 0, 0.7));
+  background: radial-gradient(circle at top left, rgba(203, 255, 0, 0.15), rgba(45, 45, 45, 0.7));
   border-radius: 12px;
   padding: 40px 24px;
-  color: #ccc;
+  color: var(--color-text-neutral);
   text-align: center;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
-  border: 2px solid #D7FB00;
+  border: 2px solid var(--color-primary);
   transition: transform 0.3s ease;
 
   overflow: visible;
@@ -63,8 +63,8 @@
 
   left: 50%;
   transform: translateX(-50%);
-  background-color: #D7FB00;
-  color: #000;
+  background-color: var(--color-primary);
+  color: var(--color-background);
   font-family: 'Anton', sans-serif;
   font-size: 1rem;
 
@@ -89,7 +89,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath d='M0,0 L0,40 M20,0 L20,40' stroke='%23D7FB00' stroke-width='1'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Cpath d='M0,0 L0,40 M20,0 L20,40' stroke='%23CBFF00' stroke-width='1'/%3E%3C/svg%3E");
   opacity: 0.07;
   pointer-events: none;
   border-radius: inherit;
@@ -102,9 +102,9 @@
 
 .plan-card.recommended {
   transform: scale(1.05);
-  border-color: #fff;
-  background: radial-gradient(circle at top left, rgba(215, 251, 0, 0.25), rgba(0, 0, 0, 0.7));
-  box-shadow: 0 0 25px rgba(215, 251, 0, 0.6);
+  border-color: var(--color-primary-hover);
+  background: radial-gradient(circle at top left, rgba(203, 255, 0, 0.25), rgba(45, 45, 45, 0.7));
+  box-shadow: 0 0 25px rgba(203, 255, 0, 0.6);
 
   padding-top: 60px;
 
@@ -118,10 +118,10 @@
   font-family: 'Anton', sans-serif;
 
   font-size: 2rem;
-  color: #D7FB00;
+  color: var(--color-primary);
   margin-bottom: 20px;
 
-  text-shadow: 1px 1px 0 #000;
+  text-shadow: 1px 1px 0 var(--color-background);
 }
 
 .plan-price {
@@ -134,7 +134,7 @@
 }
 
 
-  .plan-features {
+.plan-features {
     list-style: none;
     padding: 0;
     margin: 0;
@@ -142,7 +142,7 @@
 
     font-size: 1.4rem;
     line-height: 1.9;
-    color: #ccc;
+    color: var(--color-text-neutral);
   }
 
 

--- a/src/components/MynterSection.css
+++ b/src/components/MynterSection.css
@@ -1,6 +1,6 @@
 .mynter {
   position: relative;
-  background-color: #000;
+  background-color: var(--color-background);
   padding: 50px 20px;
   overflow: hidden;
 }
@@ -31,7 +31,7 @@
 
 .mynter-title {
   font-family: 'Anton', sans-serif;
-  color: #D7FB00;
+  color: var(--color-primary);
   font-size: 2.5rem;
   margin-bottom: 30px;
   animation: titleGlow 4s ease-in-out infinite;
@@ -39,23 +39,23 @@
 
 @keyframes titleGlow {
   0%, 100% {
-    text-shadow: 0 0 10px #D7FB00;
+    text-shadow: 0 0 10px var(--color-primary);
   }
   50% {
-    text-shadow: 0 0 20px #D7FB00;
+    text-shadow: 0 0 20px var(--color-primary);
   }
 }
 
 .mynter-text {
   font-family: 'Inter', sans-serif;
   font-size: 1.2rem;
-  color: #ccc;
+  color: var(--color-text-neutral);
   margin-bottom: 25px;
   line-height: 1.5;
 }
 
 .mynter-highlight {
-  color: #7B2FF7;
+  color: var(--color-primary);
 }
 
 
@@ -68,13 +68,13 @@
 
 .mynter-feature-card {
   position: relative;
-  background: radial-gradient(circle at top left, rgba(123, 47, 247, 0.15), rgba(0, 0, 0, 0.7));
+  background: radial-gradient(circle at top left, rgba(203, 255, 0, 0.15), rgba(45, 45, 45, 0.7));
   border-radius: 12px;
   padding: 30px 20px;
 
-  color: #ccc;
+  color: var(--color-text-neutral);
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
-  border: 2px solid #7B2FF7;
+  border: 2px solid var(--color-primary);
   transition: transform 0.3s ease;
   overflow: hidden;
   animation: cardBounce 6s ease-in-out infinite;
@@ -92,7 +92,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath d='M0 0 L0 30 M0 0 L30 0' stroke='%237B2FF7' stroke-width='0.8'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath d='M0 0 L0 30 M0 0 L30 0' stroke='%23CBFF00' stroke-width='0.8'/%3E%3C/svg%3E");
   opacity: 0.07;
   pointer-events: none;
   border-radius: inherit;
@@ -112,8 +112,8 @@
 }
 
 .mynter-button {
-  background-color: #7B2FF7;
-  color: #fff;
+  background-color: var(--color-primary);
+  color: var(--color-background);
   font-family: 'Inter', sans-serif;
   font-weight: 700;
   padding: 12px 28px;
@@ -127,16 +127,16 @@
 
 @keyframes pulseButton {
   0%, 100% {
-    box-shadow: 0 0 0 0 rgba(123, 47, 247, 0.7);
+    box-shadow: 0 0 0 0 rgba(203, 255, 0, 0.7);
   }
   50% {
-    box-shadow: 0 0 20px 5px rgba(123, 47, 247, 0.7);
+    box-shadow: 0 0 20px 5px rgba(203, 255, 0, 0.7);
   }
 }
 
 .mynter-button:hover {
-  background-color: #00C8FF;
-  color: #fff;
+  background-color: var(--color-primary-hover);
+  color: var(--color-background);
 }
 
 /* Desktop layout */

--- a/src/components/MynterSection.jsx
+++ b/src/components/MynterSection.jsx
@@ -7,7 +7,7 @@ export default function MynterSection() {
       <svg className="mynter-texture" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
         <defs>
           <pattern id="dots" patternUnits="userSpaceOnUse" width="20" height="20">
-            <circle cx="1" cy="1" r="1" fill="#D7FB00" />
+            <circle cx="1" cy="1" r="1" fill="#CBFF00" />
           </pattern>
         </defs>
         <rect width="100%" height="100%" fill="url(#dots)" />

--- a/src/components/ProgramsSection.css
+++ b/src/components/ProgramsSection.css
@@ -1,6 +1,6 @@
 .programs {
   position: relative;
-  background-color: #000;
+  background-color: var(--color-background);
   padding: 50px 20px;
   overflow: hidden;
 }
@@ -16,20 +16,20 @@
 
 .programs-title {
   font-family: 'Anton', sans-serif;
-  color: #D7FB00;
+  color: var(--color-primary);
   font-size: 3rem;
   margin-bottom: 50px;
-  text-shadow: 2px 2px 0 #000;
+  text-shadow: 2px 2px 0 var(--color-background);
   letter-spacing: 1px;
   animation: titleGlow 4s ease-in-out infinite;
 }
 
 @keyframes titleGlow {
   0%, 100% {
-    text-shadow: 2px 2px 0 #000, 0 0 10px #D7FB00;
+    text-shadow: 2px 2px 0 var(--color-background), 0 0 10px var(--color-primary);
   }
   50% {
-    text-shadow: 2px 2px 0 #000, 0 0 20px #D7FB00;
+    text-shadow: 2px 2px 0 var(--color-background), 0 0 20px var(--color-primary);
   }
 }
 
@@ -42,14 +42,14 @@
 
 .program-card {
   position: relative;
-  background: radial-gradient(circle at top left, rgba(215, 251, 0, 0.15), rgba(0, 0, 0, 0.7));
+  background: radial-gradient(circle at top left, rgba(203, 255, 0, 0.15), rgba(45, 45, 45, 0.7));
 
   border-radius: 12px;
   padding: 40px 24px;
-  color: #ccc;
+  color: var(--color-text-neutral);
   text-align: center;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
-  border: 2px solid #D7FB00;
+  border: 2px solid var(--color-primary);
   transition: transform 0.3s ease;
 
   overflow: hidden;
@@ -69,7 +69,7 @@
   content: '';
   position: absolute;
   inset: 0;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath d='M0 0 L0 30 M0 0 L30 0' stroke='%23D7FB00' stroke-width='0.8'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30'%3E%3Cpath d='M0 0 L0 30 M0 0 L30 0' stroke='%23CBFF00' stroke-width='0.8'/%3E%3C/svg%3E");
   opacity: 0.07;
   pointer-events: none;
   border-radius: inherit;
@@ -82,10 +82,10 @@
 .program-card-title {
   font-family: 'Anton', sans-serif;
   font-size: 2rem;
-  color: #D7FB00;
+  color: var(--color-primary);
   margin-bottom: 18px;
 
-  text-shadow: 1px 1px 0 #000;
+  text-shadow: 1px 1px 0 var(--color-background);
 }
 
 .program-card-text {
@@ -94,7 +94,7 @@
   font-size: 1.4rem;
   line-height: 1.9;
 
-  color: #ccc;
+  color: var(--color-text-neutral);
 }
 
 /* Desktop layout */

--- a/src/components/TestimoniosSection.css
+++ b/src/components/TestimoniosSection.css
@@ -1,6 +1,6 @@
 .testimonios {
   position: relative;
-  background-color: #000;
+  background-color: var(--color-background);
   padding: 50px 20px;
   overflow: hidden;
 }
@@ -15,7 +15,7 @@
 
 .testimonios-title {
   font-family: 'Anton', sans-serif;
-  color: #D7FB00;
+  color: var(--color-primary);
   font-size: 2.5rem;
   margin-bottom: 40px;
   animation: titleGlow 4s ease-in-out infinite;
@@ -23,10 +23,10 @@
 
 @keyframes titleGlow {
   0%, 100% {
-    text-shadow: 0 0 10px #D7FB00;
+    text-shadow: 0 0 10px var(--color-primary);
   }
   50% {
-    text-shadow: 0 0 20px #D7FB00;
+    text-shadow: 0 0 20px var(--color-primary);
   }
 }
 
@@ -38,13 +38,13 @@
 
 .testimonio-card {
   position: relative;
-  background-color: rgba(0, 0, 0, 0.7);
+  background-color: rgba(45, 45, 45, 0.7);
   border-radius: 12px;
   padding: 40px 24px;
-  color: #ccc;
+  color: var(--color-text-neutral);
   text-align: center;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.6);
-  border: 2px solid #D7FB00;
+  border: 2px solid var(--color-primary);
   transition: transform 0.3s ease;
 
   animation: cardBounce 6s ease-in-out infinite;
@@ -68,7 +68,7 @@
   height: 80px;
   object-fit: cover;
   border-radius: 50%;
-  border: 2px solid #D7FB00;
+  border: 2px solid var(--color-primary);
   margin-bottom: 15px;
 }
 
@@ -76,14 +76,14 @@
   font-family: 'Inter', sans-serif;
   font-size: 1.2rem;
   line-height: 1.5;
-  color: #ccc;
+  color: var(--color-text-neutral);
   margin-bottom: 12px;
 }
 
 .testimonio-author {
   font-family: 'Anton', sans-serif;
   font-size: 1.1rem;
-  color: #D7FB00;
+  color: var(--color-primary);
 }
 
 /* Desktop layout */

--- a/src/index.css
+++ b/src/index.css
@@ -3,13 +3,20 @@
 @tailwind utilities;
 
 :root {
+  --color-background: #202020;
+  --color-dark: #2D2D2D;
+  --color-text-neutral: #787878;
+  --color-primary: #CBFF00;
+  --color-primary-hover: #DBFE52;
+  --color-positive-bg: #F8FE9F;
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #f5f5f5;
+  background-color: var(--color-background);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -19,16 +26,18 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: var(--color-primary);
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: var(--color-primary-hover);
 }
 
-body {
+body.landing {
   margin: 0;
   font-family: 'Arial', sans-serif;
+  background-color: var(--color-background);
+  color: #f5f5f5;
 }
 
 h1 {
@@ -36,37 +45,36 @@ h1 {
   line-height: 1.1;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+.cta-button {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  padding: 12px 28px;
+  border-radius: 50px;
+  text-decoration: none;
+  display: inline-block;
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+.cta-button.primary {
+  background-color: var(--color-primary);
+  color: var(--color-background);
 }
+
+.cta-button.primary:hover {
+  background-color: var(--color-primary-hover);
+}
+
+.cta-button.secondary {
+  background-color: var(--color-dark);
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
+}
+
+.cta-button.secondary:hover {
+  background-color: var(--color-primary-hover);
+  color: var(--color-background);
+}
+
 html {
   scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- refresh palette with FitPlan variables and shared CTA styles
- restyle sections for contrast and legibility
- add routine selector button alongside WhatsApp contact

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68921e4d50fc832e9dc80295d1f9ac06