### PR TITLE
feat: add routine selector button with original styling

### DIFF
--- a/src/components/FinalSection.css
+++ b/src/components/FinalSection.css
@@ -65,6 +65,12 @@
   height: auto;
 }
 
+.final-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
 .final-button {
   background-color: #D7FB00;
   color: #000;
@@ -75,6 +81,13 @@
   text-decoration: none;
   transition: background-color 0.3s, color 0.3s;
   animation: pulseButton 3s ease-in-out infinite;
+}
+
+.final-button.secondary {
+  background-color: #000;
+  color: #D7FB00;
+  border: 2px solid #D7FB00;
+  animation: none;
 }
 
 @keyframes pulseButton {
@@ -88,6 +101,11 @@
 
 .final-button:hover {
   background-color: #fff;
+  color: #000;
+}
+
+.final-button.secondary:hover {
+  background-color: #D7FB00;
   color: #000;
 }
 
@@ -109,5 +127,9 @@
 
   .final-icon {
     width: 70px;
+  }
+
+  .final-buttons {
+    flex-direction: row;
   }
 }

--- a/src/components/FinalSection.jsx
+++ b/src/components/FinalSection.jsx
@@ -26,9 +26,19 @@ export default function FinalSection() {
 
         <div className="final-icons">
           <img src="/dumbell.png" alt="Dumbell icon" className="final-icon" />
-          <a href="https://wa.me/5493512800414" target="_blank" rel="noopener noreferrer" className="final-button">
-            Quiero mi plan
-          </a>
+          <div className="final-buttons">
+            <a href="/rutinas" className="final-button">
+              Quiero mi rutina ideal!
+            </a>
+            <a
+              href="https://wa.me/5493512800414"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="final-button secondary"
+            >
+              Hablame y empecemos a entrenar!
+            </a>
+          </div>
           <img src="/plate.png" alt="Weight plate icon" className="final-icon" />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- revert FitPlan palette changes to restore original landing design
- add "Quiero mi rutina ideal!" CTA alongside WhatsApp contact with primary/secondary styling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68921e4d50fc832e9dc80295d1f9ac06